### PR TITLE
refactor: use slice instead of vector as return type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphblas_sparse_linear_algebra"
-version = "0.4.5"
+version = "0.5.0"
 authors = ["code_sam <mail@samdekker.nl>"]
 description = "Wrapper for SuiteSparse:GraphBLAS"
 edition = "2018"
@@ -12,7 +12,7 @@ repository = "https://github.com/code-sam/graphblas_sparse_linear_algebra"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = {version = "1.7"}
+once_cell = {version = "1.8"}
 
 [features]
 default = ["build_static_graphblas_dependencies"]

--- a/src/value_types/sparse_matrix/element.rs
+++ b/src/value_types/sparse_matrix/element.rs
@@ -107,11 +107,11 @@ impl<T: ValueType + Clone + Copy> MatrixElementList<T> {
         self.value.append(&mut element_list_to_append.value);
     }
 
-    pub fn row_index_vec(&self) -> &Vec<ElementIndex> {
-        &self.row_index
+    pub fn row_indices_ref(&self) -> &[ElementIndex] {
+        &self.row_index.as_slice()
     }
 
-    pub fn row_index(&self, index: ElementIndex) -> Result<&ElementIndex, LogicError> {
+    pub(crate) fn row_index(&self, index: ElementIndex) -> Result<&ElementIndex, LogicError> {
         if index <= self.length() {
             Ok(&self.row_index[index])
         } else {
@@ -127,7 +127,7 @@ impl<T: ValueType + Clone + Copy> MatrixElementList<T> {
         }
     }
 
-    pub fn column_index(&self, index: ElementIndex) -> Result<&ElementIndex, LogicError> {
+    pub(crate) fn column_index(&self, index: ElementIndex) -> Result<&ElementIndex, LogicError> {
         if index <= self.length() {
             Ok(&self.column_index[index])
         } else {
@@ -143,12 +143,12 @@ impl<T: ValueType + Clone + Copy> MatrixElementList<T> {
         }
     }
 
-    pub fn column_index_vec(&self) -> &Vec<ElementIndex> {
-        &self.column_index
+    pub fn column_indices_ref(&self) -> &[ElementIndex] {
+        &self.column_index.as_slice()
     }
 
-    pub fn value_vec(&self) -> &Vec<T> {
-        &self.value
+    pub fn values_ref(&self) -> &[T] {
+        &self.value.as_slice()
     }
 
     pub fn length(&self) -> usize {

--- a/src/value_types/sparse_matrix/sparse_matrix.rs
+++ b/src/value_types/sparse_matrix/sparse_matrix.rs
@@ -213,9 +213,9 @@ macro_rules! implement_dispay {
                     }
                 }
 
-                let row_indices = element_list.row_index_vec();
-                let column_indices = element_list.column_index_vec();
-                let values = element_list.value_vec();
+                let row_indices = element_list.row_indices_ref();
+                let column_indices = element_list.column_indices_ref();
+                let values = element_list.values_ref();
 
                 writeln! {f,"Matrix size: {:?}", self.size()?};
                 writeln! {f,"Number of stored elements: {:?}", self.number_of_stored_elements()?};
@@ -335,7 +335,7 @@ macro_rules! sparse_matrix_from_element_vector {
                             matrix.matrix,
                             graphblas_row_indices.as_ptr(),
                             graphblas_column_indices.as_ptr(),
-                            elements.value_vec().as_ptr(),
+                            elements.values_ref().as_ptr(),
                             number_of_elements,
                             reduction_operator_for_duplicates.graphblas_type(),
                         )

--- a/src/value_types/sparse_vector/element.rs
+++ b/src/value_types/sparse_vector/element.rs
@@ -94,11 +94,12 @@ impl<T: ValueType + Clone + Copy> VectorElementList<T> {
         self.value.append(&mut element_list_to_append.value);
     }
 
-    pub fn index_vec(&self) -> &Vec<ElementIndex> {
-        &self.index
+    pub fn indices_ref(&self) -> &[ElementIndex] {
+        self.index.as_slice()
     }
 
-    pub fn index(&self, index: ElementIndex) -> Result<&ElementIndex, LogicError> {
+    pub(crate) fn index(&self, index: ElementIndex) -> Result<&ElementIndex, LogicError> {
+        // REVIEW: is this worth the runtime cost?
         if index <= self.length() {
             Ok(&self.index[index])
         } else {
@@ -114,8 +115,8 @@ impl<T: ValueType + Clone + Copy> VectorElementList<T> {
         }
     }
 
-    pub fn value_vec(&self) -> &Vec<T> {
-        &self.value
+    pub fn values_ref(&self) -> &[T] {
+        self.value.as_slice()
     }
 
     // pub fn as_element_vec(&self) -> &Vec<Element<T>> {

--- a/src/value_types/sparse_vector/sparse_vector.rs
+++ b/src/value_types/sparse_vector/sparse_vector.rs
@@ -208,8 +208,8 @@ macro_rules! implement_dispay {
                     }
                 }
 
-                let indices = element_list.index_vec();
-                let values = element_list.value_vec();
+                let indices = element_list.indices_ref();
+                let values = element_list.values_ref();
 
                 writeln! {f,"Vector length: {:?}", self.length()?};
                 writeln! {f,"Number of stored elements: {:?}", self.number_of_stored_elements()?};
@@ -276,7 +276,7 @@ macro_rules! sparse_matrix_from_element_vector {
                     $build_function(
                         vector.vector,
                         graphblas_indices.as_ptr(),
-                        elements.value_vec().as_ptr(),
+                        elements.values_ref().as_ptr(),
                         number_of_elements,
                         reduction_operator_for_duplicates.graphblas_type(),
                     )


### PR DESCRIPTION
expose values and indices of vector and matrix element list…s as a slice instead of a vector.